### PR TITLE
Match more files and improve README

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -4,5 +4,10 @@
       "tab_size": 2,
       "format_on_save": "off"
     }
+  },
+  "file_types": {
+    "Git Attributes": ["{git,.git{/info,}}/attributes"],
+    "Git Config": ["{git,.git{modules,modules/*,}}/config"],
+    "Git Ignore": ["{git,.git}/ignore", ".git/info/exclude"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,24 +2,35 @@
 
 <img width="720" src="https://s2.loli.net/2024/05/02/n8PkoAaFdrNsGZ5.png" />
 
-Support the following syntax highlighting:
+Provide the syntax highlighting for the following Languages:
 
-- git_commit
-- git_config
-- git_rebase
-- diff(TODO)
-- gitignore
-- gitattributes
+- [Git Attributes](https://github.com/tree-sitter-grammars/tree-sitter-gitattributes): .gitattributes, .git/info/attributes, etc
+- [Git Commit](https://github.com/the-mikedavis/tree-sitter-git-commit): COMMIT_EDITMSG, EDIT_DESCRIPTION, MERGE_MSG, NOTES_EDITMSG, TAG_EDITMSG
+- [Git Config](https://github.com/the-mikedavis/tree-sitter-git-config): .gitconfig, .gitmodules, .lfsconfig, config.worktree
+- [Git Ignore](https://github.com/shunsambongi/tree-sitter-gitignore): .gitignore, .dockerignore, .npmignore, .prettierignore, etc
+- [Git Rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase): git-rebase-todo
 
-# Use zed commit editor
+## Configuration
 
-> https://github.com/zed-industries/zed/issues/7048
+This extension will automatically recognize the majority of filenames/extensions out of the box, but some require some additional configuration via [`file_types`] in Zed Settings:
+
+```json
+{
+  "file_types": {
+    "Git Attributes": ["{git,.git{/info,}}/attributes"],
+    "Git Config": ["{git,.git{modules,modules/*,}}/config"],
+    "Git Ignore": ["{git,.git}/ignore", ".git/info/exclude"]
+  }
+}
+```
+
+## Use zed commit editor
 
 ```json
 {
   "terminal": {
     "env": {
-      "EDITOR": "zed --wait"
+      "GIT_EDITOR": "zed --wait"
     }
   }
 }
@@ -30,5 +41,5 @@ And Then
 ```bash
 git add .
 git commit
-git push -f # take off
+git push
 ```

--- a/extension.toml
+++ b/extension.toml
@@ -2,7 +2,10 @@ id = "git-firefly"
 name = "Git Firefly"
 version = "0.0.4"
 schema_version = 1
-authors = [ "d1y <chenhonzhou@gmail.com>" ]
+authors = [
+  "d1y <chenhonzhou@gmail.com>",
+  "Peter Tripp <petertripp@gmail.com>",
+]
 description = "Provides Git Syntax Highlighting"
 repository = "https://github.com/d1y/git_firefly"
 

--- a/languages/gitattributes/config.toml
+++ b/languages/gitattributes/config.toml
@@ -1,8 +1,8 @@
 name = "Git Attributes"
 grammar = "gitattributes"
 path_suffixes = [
-  # Refer to https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1296
-  # TODO: need match: https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1698-L1701
+  # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
+  "gitattributes",
   ".gitattributes",
 ]
 line_comments = ["# "]

--- a/languages/gitcommit/config.toml
+++ b/languages/gitcommit/config.toml
@@ -1,12 +1,12 @@
 name = "Git Commit"
 grammar = "git_commit"
 path_suffixes = [
-  # Refer to https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua#L1286-L1290
-  "TAG_EDITMSG",
-  "MERGE_MSG",
+  # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "COMMIT_EDITMSG",
-  "NOTES_EDITMSG",
   "EDIT_DESCRIPTION",
+  "MERGE_MSG",
+  "NOTES_EDITMSG",
+  "TAG_EDITMSG",
 ]
 line_comments = ["#"]
 brackets = [

--- a/languages/gitconfig/config.toml
+++ b/languages/gitconfig/config.toml
@@ -1,10 +1,11 @@
 name = "Git Config"
 grammar = "git_config"
 path_suffixes = [
-  # Refer to https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1294-L1295C5
+  # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
+  "config.worktree",
   ".gitconfig",
+  ".gitmodules",
   ".lfsconfig",
-  ".gitmodules"
 ]
 line_comments = ["; "]
 autoclose_before = "]"

--- a/languages/gitignore/config.toml
+++ b/languages/gitignore/config.toml
@@ -1,21 +1,20 @@
+path_suffixes = [
+  # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
+  ".containerignore",
+  ".cursorignore",
+  ".dockerignore",
+  ".eslintignore",
+  ".fdignore",        # https://github.com/sharkdp/fd
+  ".ignore",          # https://github.com/BurntSushi/ripgrep
+  ".npmignore",
+  ".prettierignore",
+  ".rgignore",        # https://github.com/BurntSushi/ripgrep
+  ".vscodeignore",
+]
 name = "Git Ignore"
 grammar = "gitignore"
-path_suffixes = [
-  # Refer to https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1297
-  # TODO: need match: https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1702-L1704
-  ".gitignore",
-  ".git-blame-ignore-revs",
-
-  # other? https://github.com/zed-industries/extensions/pull/649
-  ".dockerignore",
-  ".npmignore",
-  ".vscodeignore",
-  ".cursorignore",
-  ".eslintignore",
-  ".prettierignore"
-]
 line_comments = ["#"]
 autoclose_before = "]"
 brackets = [
-  { start = "[", end = "]", close = true, newline = false }
+  { start = "[", end = "]", close = true, newline = false },
 ]

--- a/languages/gitrebase/config.toml
+++ b/languages/gitrebase/config.toml
@@ -1,9 +1,7 @@
-# To be honest, I rarely use git_rebase, so maybe I'm overlooking something?
-
 name = "Git Rebase"
 grammar = "git_rebase"
 path_suffixes = [
-  # Refer to https://github.com/neovim/neovim/blob/191cca2566a8afe2b2f2744f3eb763d810cc416c/runtime/lua/vim/filetype.lua#L1299C5-L1299C20
+  # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "git-rebase-todo",
 ]
 line_comments = ["#"]


### PR DESCRIPTION
Match more files, based on neovim's [filetype.lua](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua).

Readme now includes a config example to match more based on globs:
```json
{
  "file_types": {
    "Git Attributes": ["{git,.git{/info,}}/attributes"],
    "Git Config": ["{git,.git{modules,modules/*,}}/config"],
    "Git Ignore": ["{git,.git}/ignore", ".git/info/exclude"]
  }
}
```

Additions:

- Git Ignore:
  - git/ignore
  - .git/ignore
  - .git/info/exclude
  - .ignore ([ripgrep](https://github.com/BurntSushi/ripgrep))
  - .rgignore ([ripgrep](https://github.com/BurntSushi/ripgrep))
  - .fdignore ([sharkdp/fd](https://github.com/sharkdp/fd))
- Git Config:
  - git/config
  - .git/config
  - .git/modules/config
  - .git/modules/*/config
  - .git/config.worktrees
  - .git/worktrees/*/config.worktrees
- Git Attributes:
  - git/attributes
  - git/info/attributes
  - .git/attributes
  - .git/info/attributes