### PR TITLE
Fix .gitignore / .git-blame-ignore-revs not being recognized

### DIFF
--- a/languages/gitignore/config.toml
+++ b/languages/gitignore/config.toml
@@ -5,6 +5,8 @@ path_suffixes = [
   ".dockerignore",
   ".eslintignore",
   ".fdignore",        # https://github.com/sharkdp/fd
+  ".gitignore",
+  ".git-blame-ignore-revs",
   ".ignore",          # https://github.com/BurntSushi/ripgrep
   ".npmignore",
   ".prettierignore",


### PR DESCRIPTION
- Fixes: https://github.com/zed-extensions/git_firefly/issues/22
- Regression introduced in: https://github.com/zed-extensions/git_firefly/pull/18