### PR TITLE
Use hard tabs for Git Config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,8 @@
 {
   "languages": {
+    "Git Config": {
+      "hard_tabs": true
+    },
     "TOML": {
       "tab_size": 2,
       "format_on_save": "off"

--- a/languages/gitconfig/config.toml
+++ b/languages/gitconfig/config.toml
@@ -12,3 +12,4 @@ autoclose_before = "]"
 brackets = [
   { start = "[", end = "]", close = true, newline = false },
 ]
+hard_tabs = true


### PR DESCRIPTION
Git uses hard tabs for its config files, e.g. when using git-config or git-submodule.