### PR TITLE
Add missing `line_comments` entry and normalize to have a trailing space

### DIFF
--- a/languages/gitconfig/config.toml
+++ b/languages/gitconfig/config.toml
@@ -7,7 +7,7 @@ path_suffixes = [
   ".gitmodules",
   ".lfsconfig",
 ]
-line_comments = ["; "]
+line_comments = ["# ", "; "]
 autoclose_before = "]"
 brackets = [
   { start = "[", end = "]", close = true, newline = false },

--- a/languages/gitignore/config.toml
+++ b/languages/gitignore/config.toml
@@ -15,7 +15,7 @@ path_suffixes = [
 ]
 name = "Git Ignore"
 grammar = "gitignore"
-line_comments = ["#"]
+line_comments = ["# "]
 autoclose_before = "]"
 brackets = [
   { start = "[", end = "]", close = true, newline = false },

--- a/languages/gitrebase/config.toml
+++ b/languages/gitrebase/config.toml
@@ -4,5 +4,5 @@ path_suffixes = [
   # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "git-rebase-todo",
 ]
-line_comments = ["#"]
+line_comments = ["# "]
 brackets = []


### PR DESCRIPTION
- Git Config was missing a `line_comments` entry for `#`, which I think is also preferred over `;`
- Added a trailing space to the `line_comments` entries for Git Ignore and Git Rebase for consistency