### PR TITLE
Add Code Owners language for CODEOWNERS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Provide the syntax highlighting for the following Languages:
 - [Git Config](https://github.com/the-mikedavis/tree-sitter-git-config): .gitconfig, .gitmodules, .lfsconfig, config.worktree
 - [Git Ignore](https://github.com/shunsambongi/tree-sitter-gitignore): .gitignore, .dockerignore, .npmignore, .prettierignore, etc
 - [Git Rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase): git-rebase-todo
+- [Code Owners](https://github.com/lukasmalkmus/tree-sitter-codeowners): CODEOWNERS
 
 ## Configuration
 

--- a/extension.toml
+++ b/extension.toml
@@ -24,3 +24,7 @@ commit = "41940e199ba5763abea1d21b4f717014b45f01ea"
 [grammars.gitignore]
 repository = "https://github.com/shunsambongi/tree-sitter-gitignore"
 commit = "f4685bf11ac466dd278449bcfe5fd014e94aa504"
+
+[grammars.codeowners]
+repository = "https://github.com/lukasmalkmus/tree-sitter-codeowners"
+commit = "5fc25f72a44d2fe5b9218c712062dcec79dac87e"

--- a/languages/codeowners/config.toml
+++ b/languages/codeowners/config.toml
@@ -1,0 +1,5 @@
+name = "Code Owners"
+grammar = "codeowners"
+path_suffixes = ["CODEOWNERS"]
+line_comments = ["# "]
+tab_size = 2

--- a/languages/codeowners/highlights.scm
+++ b/languages/codeowners/highlights.scm
@@ -1,0 +1,32 @@
+; Comments
+(comment) @comment
+
+(comment_text) @comment
+
+; Section headers
+(section
+  "[" @punctuation.bracket
+  name: (section_name) @title
+  "]" @punctuation.bracket)
+
+; Patterns
+(pattern) @string.special.path
+
+; Wildcards
+(wildcard_pattern) @operator
+
+; Owners
+(username
+  "@" @punctuation.special
+  name: (identifier) @variable)
+
+(team
+  "@" @punctuation.special
+  org: (identifier) @namespace
+  "/" @punctuation.delimiter
+  name: (identifier) @variable)
+
+(email) @string.special.url
+
+; Identifiers
+(identifier) @variable


### PR DESCRIPTION
Add support for `CODEOWNERS` files

Links:
- [lukasmalkmus/tree-sitter-codeowners](https://github.com/lukasmalkmus/tree-sitter-codeowners)
- [GitHub Code Owners Docs](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- [GitLab Code Owners Docs](https://docs.gitlab.com/user/project/codeowners/)
- [BitBucket Code Owners Docs](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/)