### PR TITLE
Add `modeline_aliases` for git filetypes

### DIFF
--- a/languages/gitattributes/config.toml
+++ b/languages/gitattributes/config.toml
@@ -1,5 +1,6 @@
 name = "Git Attributes"
 grammar = "gitattributes"
+modeline_aliases = ["gitattributes"]
 path_suffixes = [
   # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "gitattributes",

--- a/languages/gitconfig/config.toml
+++ b/languages/gitconfig/config.toml
@@ -1,5 +1,6 @@
 name = "Git Config"
 grammar = "git_config"
+modeline_aliases = ["gitconfig"]
 path_suffixes = [
   # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "config.worktree",

--- a/languages/gitignore/config.toml
+++ b/languages/gitignore/config.toml
@@ -16,6 +16,7 @@ path_suffixes = [
 ]
 name = "Git Ignore"
 grammar = "gitignore"
+modeline_aliases = ["gitignore"]
 line_comments = ["# "]
 autoclose_before = "]"
 brackets = [

--- a/languages/gitrebase/config.toml
+++ b/languages/gitrebase/config.toml
@@ -1,5 +1,6 @@
 name = "Git Rebase"
 grammar = "git_rebase"
+modeline_aliases = ["gitrebase"]
 path_suffixes = [
   # https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua
   "git-rebase-todo",


### PR DESCRIPTION
Git Firefly's file type display names/grammar names/modeline aliases don't line up with the canonical ones for emacs and vim. Therefore if you have the following modeline at the top of your file, as would be expected for emacs, Zed does not respect it:

 ```
# -*- mode: gitconfig -*-
```

This is because the name `gitconfig` isn't registered anywhere. This PR aims to fix that using `modeline_aliases` for the gitconfig, gitignore, gitattributes and gitrebase file types.
